### PR TITLE
hotfix - assign interface to ip while updating server

### DIFF
--- a/netbox_agent/network.py
+++ b/netbox_agent/network.py
@@ -154,8 +154,8 @@ class Network():
                             status=1,
                         )
                     else:
-                        if netbox_ip.device != device:
-                            netbox_ip.device = device
+                        if netbox_ip.interface != interface:
+                            netbox_ip.interface = interface
                             netbox_ip.save()
             if nic_update:
                 interface.save()


### PR DESCRIPTION
An `IP` has an interface, not a device
Must have messed up while merge the device update PR